### PR TITLE
Add fix for incorrect status code, add restify example

### DIFF
--- a/lib/signature.js
+++ b/lib/signature.js
@@ -4,7 +4,6 @@ var signature = module.exports;
 
 var Promise = require('es6-promise').Promise;
 var base64url = require('base64url');
-var getRawBody = require('raw-body');
 var ed25519 = require('ed25519');
 var url = require('url');
 
@@ -22,7 +21,7 @@ var PERMITTED_SKEW_IN_MS = 5 * 60 * 1000; // 5 minutes
  */
 function Signature(req, buf) {
   this.req = req;
-  this.rawBody = buf;
+  this.rawBody = buf || req.rawBody;
 
   this.xSignature = (req.headers['x-signature'] || '').split(' ');
   this.signature = base64url.toBuffer(this.xSignature[0] || '');
@@ -89,7 +88,7 @@ Signature.prototype._goodSignature = function(masterKey) {
       mk = base64url.toBuffer(mk);
     }
     if (!self._validBuffers(mk)) {
-      throw new errors.ValidationFailed('invalid signature size');
+      throw new Error('invalid signature size');
     }
     if (!ed25519.Verify(self.publicKey, self.endorsement, mk)) {
       throw new Error('failed to verify endorsement');
@@ -123,13 +122,11 @@ Signature.prototype._canonize = function(req) {
     // Canonize the parameters of the request
     self._canonizeOptions(req)
     .then(function(msg) {
-      return self._readBody(req)
-      .then(function(body) {
-        req.body = body;
-        // Append the body to the message and return
-        msg += body;
-        return msg;
-      });
+      // Append the body to the message and return
+      if (self.rawBody) {
+        msg += self.rawBody;
+      }
+      return msg;
     })
     .then(resolve)
     .catch(reject);
@@ -155,23 +152,6 @@ Signature.prototype._canonizeOptions = function(req) {
     msg += key + ': ' + value + '\n';
   });
   return Promise.resolve(msg);
-};
-
-Signature.prototype._readBody = function(req) {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    if (self.rawBody) {
-      return resolve(self.rawBody);
-    }
-    getRawBody(req, function(err, raw) {
-      if (err) {
-        req.resume();
-        return reject(err);
-      }
-
-      resolve(raw);
-    });
-  });
 };
 
 signature.Signature = Signature;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "base64url": "^2.0.0",
     "ed25519": "^0.0.4",
-    "es6-promise": "^4.1.0",
-    "raw-body": "^2.2.0"
+    "es6-promise": "^4.1.0"
   },
   "devDependencies": {
+    "raw-body": "^2.2.0",
     "assert": "^1.4.1",
     "body-parser": "^1.17.1",
     "express": "^4.15.2",

--- a/test/integration/express.js
+++ b/test/integration/express.js
@@ -38,8 +38,8 @@ describe('express middleware', function() {
   it('rejects a request due to invalid signature header', function(done) {
     bootstrap.sendRequest(mocks.invalidSignature, function(err, res, body) {
       assert.equal(err, null);
-      assert.strictEqual(res.statusCode, 400);
-      assert.strictEqual(body, 'invalid signature size', 'Incorrect error reason');
+      assert.strictEqual(res.statusCode, 401);
+      assert.strictEqual(body, 'invalid signature', 'Incorrect error reason');
       done();
     });
   });
@@ -65,7 +65,7 @@ describe('express middleware', function() {
   it('rejects a request due to missing headers', function(done) {
     bootstrap.sendRequest(mocks.invalidSignature, function(err, res) {
       assert.equal(err, null);
-      assert.strictEqual(res.statusCode, 400);
+      assert.strictEqual(res.statusCode, 401);
       done();
     });
   });

--- a/test/integration/signature.js
+++ b/test/integration/signature.js
@@ -40,8 +40,8 @@ describe('signature verification', function() {
       bootstrap.sendRequest(mocks.invalidSignature, function(err, res, body) {
         server.close();
         assert.equal(err, null);
-        assert.strictEqual(res.statusCode, 400);
-        assert.strictEqual(body, 'invalid signature size', 'Incorrect error reason');
+        assert.strictEqual(res.statusCode, 401);
+        assert.strictEqual(body, 'invalid signature', 'Incorrect error reason');
         done();
       });
     });


### PR DESCRIPTION
- Incorrect status was being returned for invalid params
- Added example for restify
- Removed restreaming of body in favor of supplying raw body